### PR TITLE
Minor bpaf improvements

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,10 @@ use sha2::{Digest, Sha256};
 #[derive(Debug, Clone, Bpaf)]
 #[bpaf(options)]
 struct Args {
-    #[bpaf(external, map(Some), fallback(None))]
+    #[bpaf(external, optional)]
     fs: Option<Fs>,
 
-    #[bpaf(external, map(Some), fallback(None))]
+    #[bpaf(external, optional)]
     cache: Option<Cache>,
 
     #[bpaf(external)]


### PR DESCRIPTION
Usage of `external` looks great but you can encode optional fields with `optional`. It should do the same - can't test because sys library won't compile on my machine.